### PR TITLE
Fix: Add Path for PeerChannels

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -104,6 +104,7 @@ type PaymentACK struct {
 // PeerChannelData holds peer channel information for subscribing to and reading from a peer channel.
 type PeerChannelData struct {
 	Host      string `json:"host"`
+	Path      string `json:"path"`
 	ChannelID string `json:"channel_id"`
 	Token     string `json:"token"`
 }


### PR DESCRIPTION
Currently peer channels assumed that the API is hosted top level, which may not necessarily be the case.

The adds a path field so non-top level setups can be accounted for.